### PR TITLE
fix: replace std::unique_ptr<void> with raw pointer for MSVC compatib…

### DIFF
--- a/src/openai/OpenAIHttpClient.cpp
+++ b/src/openai/OpenAIHttpClient.cpp
@@ -100,7 +100,8 @@ class OpenAIHttpClient::HttpClientImpl {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
     std::unique_ptr<httplib::SSLClient> client_;
 #else
-    std::unique_ptr<void> client_;  // Placeholder when SSL not available
+    void* client_;  // Placeholder when SSL not available (raw pointer to avoid unique_ptr<void>
+                    // issues)
 #endif
     std::string hostname_;
     std::string basePath_;


### PR DESCRIPTION
…ility

- std::unique_ptr<void> is invalid C++ and causes compilation errors on MSVC
- Changed to raw pointer in #else branch (when SSL not available)
- This is safe because the constructor throws an exception in this case
- Fixes Windows builds with MSVC compiler

Resolves compilation error:
error C2070: '_Ty': illegal sizeof operand with [_Ty=void] error C2338: static_assert failed: 'can't delete an incomplete type'