### PR TITLE
fix: make release branches actually create releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ env:
 jobs:
   check-open-prs:
     runs-on: ubuntu-latest
-    # Only run PR check for tag-based releases, not branch pushes
-    if: startsWith(github.ref, 'refs/tags/')
     outputs:
       has_open_prs: ${{ steps.check.outputs.has_open_prs }}
     steps:
@@ -41,7 +39,7 @@ jobs:
 
   validate-version:
     needs: [check-open-prs]
-    if: startsWith(github.ref, 'refs/tags/') && needs.check-open-prs.outputs.has_open_prs == 'false'
+    if: needs.check-open-prs.outputs.has_open_prs == 'false'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.extract.outputs.version }}
@@ -50,20 +48,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Extract version from tag
+      - name: Extract version from tag or branch
         id: extract
         run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-          echo "version=${TAG}" >> $GITHUB_OUTPUT
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            # Extract from tag
+            VERSION=${GITHUB_REF#refs/tags/v}
+          elif [[ $GITHUB_REF == refs/heads/release/* ]]; then
+            # Extract from release branch name
+            VERSION=${GITHUB_REF#refs/heads/release/v}
+          else
+            echo "❌ Unsupported ref: $GITHUB_REF"
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
           # Check if this is a prerelease (contains alpha, beta, rc)
-          if [[ $TAG =~ (alpha|beta|rc) ]]; then
+          if [[ $VERSION =~ (alpha|beta|rc) ]]; then
             echo "is_prerelease=true" >> $GITHUB_OUTPUT
           else
             echo "is_prerelease=false" >> $GITHUB_OUTPUT
           fi
 
-          echo "Detected version: $TAG"
+          echo "Detected version: $VERSION"
 
       - name: Validate version format
         run: |
@@ -113,7 +121,7 @@ jobs:
 
   create-release:
     needs: [check-open-prs, validate-version]
-    if: startsWith(github.ref, 'refs/tags/') && needs.check-open-prs.outputs.has_open_prs == 'false'
+    if: needs.check-open-prs.outputs.has_open_prs == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -137,10 +145,19 @@ jobs:
           cat release_notes.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Create git tag (if from release branch)
+        if: startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          VERSION="${{ needs.validate-version.outputs.version }}"
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ startsWith(github.ref, 'refs/heads/release/') && format('v{0}', needs.validate-version.outputs.version) || github.ref_name }}
           name: "llmcpp ${{ needs.validate-version.outputs.version }}"
           body: ${{ steps.changelog.outputs.changelog }}
           prerelease: ${{ needs.validate-version.outputs.is_prerelease }}


### PR DESCRIPTION
- Remove tag-only conditions from release jobs
- Extract version from both tags and release branch names
- Automatically create git tag when triggered from release branch
- This makes release branches functional - they now create releases as expected