### PR TITLE
fix: Windows compilation error with std::unique_ptr<void>

### DIFF
--- a/src/openai/OpenAIHttpClient.cpp
+++ b/src/openai/OpenAIHttpClient.cpp
@@ -100,7 +100,7 @@ class OpenAIHttpClient::HttpClientImpl {
 #ifdef CPPHTTPLIB_OPENSSL_SUPPORT
     std::unique_ptr<httplib::SSLClient> client_;
 #else
-    std::unique_ptr<void> client_;  // Placeholder when SSL not available
+    void* client_;  // Placeholder when SSL not available (raw pointer for Windows compatibility)
 #endif
     std::string hostname_;
     std::string basePath_;


### PR DESCRIPTION
- Replace std::unique_ptr<void> with raw pointer for Windows/MSVC compatibility
- MSVC doesn't allow std::unique_ptr<void> due to incomplete type deletion
- This fixes the 'illegal sizeof operand' and 'can't delete incomplete type' errors