### PR TITLE
fix: prevent creation of branch-named tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ startsWith(github.ref, 'refs/heads/release/') && format('v{0}', needs.validate-version.outputs.version) || github.ref_name }}
+          tag_name: v${{ needs.validate-version.outputs.version }}
           name: "llmcpp ${{ needs.validate-version.outputs.version }}"
           body: ${{ steps.changelog.outputs.changelog }}
           prerelease: ${{ needs.validate-version.outputs.is_prerelease }}


### PR DESCRIPTION
The release workflow had a dangerous fallback in the tag_name field: tag_name: ${{ condition && 'v{version}' || github.ref_name }}

When the condition failed, it would create a tag named after the branch (e.g., 'main' tag instead of 'v1.1.0' tag), causing git reference ambiguity issues.

Fixed by always using the version-based tag name:
tag_name: v${{ needs.validate-version.outputs.version }}

This prevents accidental creation of branch-named tags that can cause 'refname is ambiguous' errors and git checkout issues.