### PR TITLE
Include ResponseParser.h in main llmcpp.h header

### DIFF
--- a/include/llmcpp.h
+++ b/include/llmcpp.h
@@ -13,6 +13,7 @@
 #include "core/JsonSchemaBuilder.h"
 #include "core/LLMClient.h"
 #include "core/LLMTypes.h"
+#include "core/ResponseParser.h"
 
 // OpenAI provider
 #include "openai/OpenAIClient.h"


### PR DESCRIPTION
- Fixes missing ResponseParser and ParsedResult types in aideas-suite
- Ensures these core types are available when including llmcpp.h
- Resolves CI build failures with 'core/ResponseParser.h' file not found