### PR TITLE
Fix/mcp tools deserialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,6 @@ else()
     add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# Find dependencies
-find_package(OpenSSL REQUIRED)
-
 # Use FetchContent for dependencies
 include(FetchContent)
 
@@ -50,10 +47,20 @@ FetchContent_Declare(
     GIT_TAG v0.15.3
 )
 
-# Configure httplib to use OpenSSL and disable unnecessary features
-set(HTTPLIB_USE_OPENSSL ON)
-set(HTTPLIB_USE_ZLIB OFF CACHE BOOL "" FORCE)
-set(HTTPLIB_USE_BROTLI OFF CACHE BOOL "" FORCE)
+# Configure httplib to use native SSL and disable unnecessary features
+# - macOS: Uses SecureTransport (via Security framework)
+# - Windows: Uses WinSSL/Schannel (via crypt32)
+# - Linux: Would need OpenSSL, but we primarily target macOS/Windows
+set(HTTPLIB_USE_OPENSSL OFF CACHE BOOL "Use OpenSSL" FORCE)
+set(HTTPLIB_USE_ZLIB OFF CACHE BOOL "Use zlib" FORCE)
+set(HTTPLIB_USE_BROTLI OFF CACHE BOOL "Use Brotli" FORCE)
+
+# Enable platform-specific SSL
+if(APPLE)
+    set(HTTPLIB_USE_SECURE_TRANSPORT ON CACHE BOOL "Use SecureTransport on macOS" FORCE)
+elseif(WIN32)
+    set(HTTPLIB_USE_WINSSL ON CACHE BOOL "Use WinSSL on Windows" FORCE)
+endif()
 
 # Make dependencies available
 FetchContent_MakeAvailable(nlohmann_json httplib)
@@ -97,8 +104,6 @@ target_link_libraries(llmcpp
         nlohmann_json
     PRIVATE
         httplib::httplib
-        OpenSSL::SSL 
-        OpenSSL::Crypto
 )
 
 # Platform-specific libraries

--- a/src/openai/OpenAITypes.cpp
+++ b/src/openai/OpenAITypes.cpp
@@ -71,10 +71,18 @@ ResponsesRequest ResponsesRequest::fromLLMRequest(const LLMRequest& request) {
     // Handle tools from extensions (if present)
     if (hasTools(request.config)) {
         json toolsJson = getToolsJson(request.config);
-        // Tools are stored as JSON - we need to deserialize them into ToolVariant
-        // For now, we'll parse them on a best-effort basis
-        // TODO: Implement proper tool deserialization
-        responsesReq.tools.clear();  // Clear any existing tools
+        responsesReq.tools.clear();
+
+        // Convert JSON tools array to ToolVariant vector
+        for (const auto& toolJson : toolsJson) {
+            if (toolJson.contains("type")) {
+                std::string toolType = toolJson["type"].get<std::string>();
+                if (toolType == "mcp") {
+                    McpTool mcpTool = McpTool::fromJson(toolJson);
+                    responsesReq.tools.push_back(mcpTool);
+                }
+            }
+        }
     }
 
     // Handle JSON schema for structured outputs


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Deserializes MCP tools from `extensions.tools` into `responsesReq.tools` during `ResponsesRequest::fromLLMRequest`.
> 
> - **OpenAI tooling**:
>   - **Tool deserialization**: Parse `extensions["tools"]` and convert items with `type == "mcp"` via `McpTool::fromJson`, clearing and populating `responsesReq.tools` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7962304d52c9f39bccec8187cdf85f1d9d57f8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->